### PR TITLE
refactor!: Rename `--server-id` to `--device-name`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Written in Rust, Webterm is built from the ground up for security, performance, 
 
 2. Start the Webterm agent:
    ```bash
-   webterm-agent --server-id <SERVER_ID> --secret-key <SECRET_KEY>
+   webterm-agent --device-name <DEVICE_NAME> --secret-key <SECRET_KEY>
    ```
 
 3. Access the terminal on [https://webterm.run](https://webterm.run) using the same credentials.
@@ -54,7 +54,6 @@ _(Binary distributions and detailed installation instructions for more platforms
 ## Screenshots
 
 ![image](https://github.com/user-attachments/assets/06240ef7-e51d-4176-a957-87948688f8a6)
-
 
 ## How It Works
 

--- a/agent/src/args.rs
+++ b/agent/src/args.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 #[command(version, about = "Learn more at https://github.com/nasa42/webterm", long_about = None)]
 pub struct Args {
     /// Server ID, must be unique at least 16 characters long
-    #[arg(long, env = "WT_SERVER_ID")]
-    pub server_id: String,
+    #[arg(long, env = "WT_DEVICE_NAME")]
+    pub device_name: String,
 
     #[arg(long, env = "WT_SECRET_KEY")]
     pub secret_key: String,

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -29,8 +29,8 @@ impl Config {
         }
     }
 
-    pub fn server_id(&self) -> &String {
-        &self.args.server_id
+    pub fn device_name(&self) -> &String {
+        &self.args.device_name
     }
 
     pub fn secret_key(&self) -> &String {

--- a/core/src/generated/flatbuffers_schema/handshake_v1/f2r_handshake_generated.rs
+++ b/core/src/generated/flatbuffers_schema/handshake_v1/f2r_handshake_generated.rs
@@ -26,7 +26,7 @@ impl<'a> flatbuffers::Follow<'a> for F2rHandshake<'a> {
 
 impl<'a> F2rHandshake<'a> {
   pub const VT_FRONTEND_VERSION: flatbuffers::VOffsetT = 4;
-  pub const VT_SERVER_ID: flatbuffers::VOffsetT = 6;
+  pub const VT_DEVICE_NAME: flatbuffers::VOffsetT = 6;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -38,7 +38,7 @@ impl<'a> F2rHandshake<'a> {
     args: &'args F2rHandshakeArgs<'args>
   ) -> flatbuffers::WIPOffset<F2rHandshake<'bldr>> {
     let mut builder = F2rHandshakeBuilder::new(_fbb);
-    if let Some(x) = args.server_id { builder.add_server_id(x); }
+    if let Some(x) = args.device_name { builder.add_device_name(x); }
     if let Some(x) = args.frontend_version { builder.add_frontend_version(x); }
     builder.finish()
   }
@@ -52,11 +52,11 @@ impl<'a> F2rHandshake<'a> {
     unsafe { self._tab.get::<Version>(F2rHandshake::VT_FRONTEND_VERSION, None)}
   }
   #[inline]
-  pub fn server_id(&self) -> Option<&'a str> {
+  pub fn device_name(&self) -> Option<&'a str> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(F2rHandshake::VT_SERVER_ID, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(F2rHandshake::VT_DEVICE_NAME, None)}
   }
 }
 
@@ -68,21 +68,21 @@ impl flatbuffers::Verifiable for F2rHandshake<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<Version>("frontend_version", Self::VT_FRONTEND_VERSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("server_id", Self::VT_SERVER_ID, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("device_name", Self::VT_DEVICE_NAME, false)?
      .finish();
     Ok(())
   }
 }
 pub struct F2rHandshakeArgs<'a> {
     pub frontend_version: Option<&'a Version>,
-    pub server_id: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub device_name: Option<flatbuffers::WIPOffset<&'a str>>,
 }
 impl<'a> Default for F2rHandshakeArgs<'a> {
   #[inline]
   fn default() -> Self {
     F2rHandshakeArgs {
       frontend_version: None,
-      server_id: None,
+      device_name: None,
     }
   }
 }
@@ -97,8 +97,8 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> F2rHandshakeBuilder<'a, 'b, A> 
     self.fbb_.push_slot_always::<&Version>(F2rHandshake::VT_FRONTEND_VERSION, frontend_version);
   }
   #[inline]
-  pub fn add_server_id(&mut self, server_id: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(F2rHandshake::VT_SERVER_ID, server_id);
+  pub fn add_device_name(&mut self, device_name: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(F2rHandshake::VT_DEVICE_NAME, device_name);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> F2rHandshakeBuilder<'a, 'b, A> {
@@ -119,7 +119,7 @@ impl core::fmt::Debug for F2rHandshake<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut ds = f.debug_struct("F2rHandshake");
       ds.field("frontend_version", &self.frontend_version());
-      ds.field("server_id", &self.server_id());
+      ds.field("device_name", &self.device_name());
       ds.finish()
   }
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,7 +3,7 @@ import tsEsLint from "typescript-eslint";
 
 export default [
   {
-    ignores: [".astro/", "src/env.d.ts", "src/generated/flatbuffers_schema/"],
+    ignores: [".astro/", "dist/", "src/env.d.ts", "src/generated/flatbuffers_schema/"],
   },
   ...tsEsLint.configs.recommended,
   ...eslintPluginAstro.configs["flat/recommended"],

--- a/frontend/src/generated/flatbuffers_schema/handshake_v1/f2r-handshake.ts
+++ b/frontend/src/generated/flatbuffers_schema/handshake_v1/f2r-handshake.ts
@@ -30,9 +30,9 @@ frontendVersion(obj?:Version):Version|null {
   return offset ? (obj || new Version()).__init(this.bb_pos + offset, this.bb!) : null;
 }
 
-serverId():string|null
-serverId(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
-serverId(optionalEncoding?:any):string|Uint8Array|null {
+deviceName():string|null
+deviceName(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
+deviceName(optionalEncoding?:any):string|Uint8Array|null {
   const offset = this.bb!.__offset(this.bb_pos, 6);
   return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
 }
@@ -45,8 +45,8 @@ static addFrontendVersion(builder:flatbuffers.Builder, frontendVersionOffset:fla
   builder.addFieldStruct(0, frontendVersionOffset, 0);
 }
 
-static addServerId(builder:flatbuffers.Builder, serverIdOffset:flatbuffers.Offset) {
-  builder.addFieldOffset(1, serverIdOffset, 0);
+static addDeviceName(builder:flatbuffers.Builder, deviceNameOffset:flatbuffers.Offset) {
+  builder.addFieldOffset(1, deviceNameOffset, 0);
 }
 
 static endF2rHandshake(builder:flatbuffers.Builder):flatbuffers.Offset {
@@ -54,10 +54,10 @@ static endF2rHandshake(builder:flatbuffers.Builder):flatbuffers.Offset {
   return offset;
 }
 
-static createF2rHandshake(builder:flatbuffers.Builder, frontendVersionOffset:flatbuffers.Offset, serverIdOffset:flatbuffers.Offset):flatbuffers.Offset {
+static createF2rHandshake(builder:flatbuffers.Builder, frontendVersionOffset:flatbuffers.Offset, deviceNameOffset:flatbuffers.Offset):flatbuffers.Offset {
   F2rHandshake.startF2rHandshake(builder);
   F2rHandshake.addFrontendVersion(builder, frontendVersionOffset);
-  F2rHandshake.addServerId(builder, serverIdOffset);
+  F2rHandshake.addDeviceName(builder, deviceNameOffset);
   return F2rHandshake.endF2rHandshake(builder);
 }
 }

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -46,7 +46,7 @@ import Layout from "../layouts/Layout.astro";
                   cargo install webterm-agent <br />
                   <br />
                   # Run the agent <br />
-                  webterm-agent --server-id &lt;server-id&gt; --secret-key &lt;secret-key&gt;
+                  webterm-agent --device-name &lt;DEVICE_NAME&gt; --secret-key &lt;SECRET_KEY&gt;
                 </code>
               </div>
               <div class="mt-3">
@@ -67,8 +67,8 @@ import Layout from "../layouts/Layout.astro";
             <div class="card-body p-4">
               <form id="app-homepage-form">
                 <div class="mb-4">
-                  <label for="app-server-id" class="form-label fw-medium">Server ID</label>
-                  <input type="text" class="form-control form-control-lg" id="app-server-id" name="server-id" />
+                  <label for="app-device-name" class="form-label fw-medium">Server ID</label>
+                  <input type="text" class="form-control form-control-lg" id="app-device-name" name="device-name" />
                 </div>
                 <div class="mb-4">
                   <label for="app-secret-key" class="form-label fw-medium">Secret Key</label>

--- a/frontend/src/scripts/client/entry-points/homepage.ts
+++ b/frontend/src/scripts/client/entry-points/homepage.ts
@@ -10,7 +10,7 @@ const init = async () => {
 
   $form.addEventListener("submit", async (e) => {
     e.preventDefault();
-    const $serverId = $form.querySelector("input[name='server-id']") as HTMLInputElement;
+    const $serverId = $form.querySelector("input[name='device-name']") as HTMLInputElement;
     const $secretKey = $form.querySelector("input[name='secret-key']") as HTMLInputElement;
     const serverId = $serverId.value;
     const secretKey = $secretKey.value;

--- a/frontend/src/scripts/client/functions/createF2rHandshake.ts
+++ b/frontend/src/scripts/client/functions/createF2rHandshake.ts
@@ -1,15 +1,15 @@
 import * as flatbuffers from "flatbuffers";
 import { F2rHandshake, Version } from "../../../generated/flatbuffers_schema/handshake_v1/handshake_v1.ts";
 
-export const createF2rHandshake = (serverId: string): Uint8Array => {
+export const createF2rHandshake = (deviceName: string): Uint8Array => {
   const builder = new flatbuffers.Builder(1024);
 
-  const serverIdOffset = builder.createString(serverId);
+  const deviceNameOffset = builder.createString(deviceName);
 
   F2rHandshake.startF2rHandshake(builder);
   const versionOffset = Version.createVersion(builder, 0, 1, 0);
   F2rHandshake.addFrontendVersion(builder, versionOffset);
-  F2rHandshake.addServerId(builder, serverIdOffset);
+  F2rHandshake.addDeviceName(builder, deviceNameOffset);
   const offset = F2rHandshake.endF2rHandshake(builder);
 
   builder.finish(offset);

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 // TODO: remove me once handshake is implemented
-pub const TEST_SERVER_ID: &str = "test";
+pub const TEST_DEVICE_NAME: &str = "test";
 
 pub const WEBSOCKET_BUFFER_SIZE: usize = 1024 * 16;
 pub const WEBSOCKET_MAX_BUFFER_SIZE: usize = 1024 * 64;

--- a/relay/src/controllers/handshake_v1.rs
+++ b/relay/src/controllers/handshake_v1.rs
@@ -17,7 +17,7 @@ pub async fn frontend_handler(body: Bytes) -> Result<Response, StatusCode> {
 #[axum::debug_handler]
 pub async fn agent_handler(_body: Bytes) -> impl IntoResponse {
     // purpose
-    // ask relay if a server_id exists
+    // ask relay if a device_name exists
     // ask frontend to perform proof of work
     // create an "auth_nonce" which can be used to establish a websocket connection
     ""

--- a/relay/src/controllers/talk_v1.rs
+++ b/relay/src/controllers/talk_v1.rs
@@ -1,4 +1,4 @@
-use crate::config::TEST_SERVER_ID;
+use crate::config::TEST_DEVICE_NAME;
 use crate::models::agent_connection::AgentConnection;
 use crate::models::agent_registry::AgentRegistry;
 use crate::models::bridge::Bridge;
@@ -44,7 +44,7 @@ async fn on_upgrade_frontend(socket: WebSocket, handshake_nonce: String) {
 
 async fn on_upgrade_agent(socket: WebSocket) {
     info!("Starting new WebSocket connection for agent");
-    let connection = Arc::new(AgentConnection::new(TEST_SERVER_ID.to_string(), socket).await);
+    let connection = Arc::new(AgentConnection::new(TEST_DEVICE_NAME.to_string(), socket).await);
     AgentRegistry::register(connection.clone())
         .await
         .expect("Failed to register agent");

--- a/relay/src/handshake/process_f2r_handshake.rs
+++ b/relay/src/handshake/process_f2r_handshake.rs
@@ -6,16 +6,16 @@ use webterm_core::generated::flatbuffers_schema::handshake_v1::F2rHandshake;
 use webterm_core::handshake_v1_helpers::create_r2f_handshake;
 
 pub async fn process_f2r_handshake(message: F2rHandshake<'_>) -> Vec<u8> {
-    let req_server_id = message.server_id();
+    let req_device_name = message.device_name();
 
-    match req_server_id {
+    match req_device_name {
         None => {
-            error!("No server_id in F2rHandshake");
+            error!("No device_name in F2rHandshake");
             r2f_success_false_message()
         }
-        Some(server_id) => {
-            debug!("Processing F2rHandshake for server_id: {}", server_id);
-            let agent = AgentRegistry::find(server_id).await;
+        Some(device_name) => {
+            debug!("Processing F2rHandshake for device_name: {}", device_name);
+            let agent = AgentRegistry::find(device_name).await;
             debug!("finished finding agent");
             match agent {
                 Err(_) => {
@@ -23,10 +23,10 @@ pub async fn process_f2r_handshake(message: F2rHandshake<'_>) -> Vec<u8> {
                     r2f_success_false_message()
                 }
                 Ok(agent) => {
-                    info!("Found agent: {}", agent.server_id);
+                    info!("Found agent: {}", agent.device_name);
                     let auth_nonce = HandshakeNonceRegistry::singleton_frontend()
                         .await
-                        .create_nonce(agent.server_id.clone())
+                        .create_nonce(agent.device_name.clone())
                         .await;
 
                     match auth_nonce {

--- a/relay/src/models/agent_connection.rs
+++ b/relay/src/models/agent_connection.rs
@@ -7,7 +7,7 @@ use tokio::sync::Notify;
 use webterm_core::types::FrontendId;
 
 pub struct AgentConnection {
-    pub server_id: String,
+    pub device_name: String,
     agent_writer: SocketWriter,
     agent_reader: SocketReader,
     close_notifier: Notify,
@@ -15,13 +15,13 @@ pub struct AgentConnection {
 }
 
 impl AgentConnection {
-    pub async fn new(server_id: String, socket: WebSocket) -> Self {
+    pub async fn new(device_name: String, socket: WebSocket) -> Self {
         let (agent_writer, agent_reader) = socket.split();
         let agent_reader = SocketReader::new(agent_reader);
         let agent_writer = SocketWriter::new(agent_writer);
 
         Self {
-            server_id,
+            device_name,
             agent_writer,
             agent_reader,
             close_notifier: Notify::new(),

--- a/relay/src/models/agent_registry.rs
+++ b/relay/src/models/agent_registry.rs
@@ -20,15 +20,15 @@ impl AgentRegistry {
         })
     }
 
-    pub async fn find(server_id: &str) -> Result<Arc<AgentConnection>, RelayError> {
-        debug!("finding agent {}", server_id);
+    pub async fn find(device_name: &str) -> Result<Arc<AgentConnection>, RelayError> {
+        debug!("finding agent {}", device_name);
         let registry = Self::singleton().await;
         debug!("registry acquired");
         Ok(registry
             .agents
             .read()
             .await
-            .get(&server_id.to_string())
+            .get(&device_name.to_string())
             .ok_or(RelayError::AgentNotFound)?
             .clone())
     }
@@ -40,24 +40,24 @@ impl AgentRegistry {
                 "Agent registry is full".to_string(),
             ));
         }
-        debug!("Registering agent {}", agent.server_id);
+        debug!("Registering agent {}", agent.device_name);
         registry
             .agents
             .write()
             .await
-            .insert(agent.server_id.clone(), agent);
+            .insert(agent.device_name.clone(), agent);
 
         Ok(())
     }
 
     #[allow(dead_code)]
-    pub async fn remove(server_id: &str) -> Result<Arc<AgentConnection>, RelayError> {
+    pub async fn remove(device_name: &str) -> Result<Arc<AgentConnection>, RelayError> {
         let registry = Self::singleton().await;
         registry
             .agents
             .write()
             .await
-            .remove(&server_id.to_string())
+            .remove(&device_name.to_string())
             .ok_or(RelayError::AgentNotFound)
     }
 }

--- a/relay/src/models/handshake_nonce_registry.rs
+++ b/relay/src/models/handshake_nonce_registry.rs
@@ -38,19 +38,19 @@ impl HandshakeNonceRegistry {
         frontend
     }
 
-    pub async fn create_nonce(&self, server_id: String) -> Result<String, RelayError> {
+    pub async fn create_nonce(&self, device_name: String) -> Result<String, RelayError> {
         let nonce = random_string(64);
 
         self.map
-            .insert(nonce.clone(), server_id, HANDSHAKE_NONCE_EXPIRE_IN)
+            .insert(nonce.clone(), device_name, HANDSHAKE_NONCE_EXPIRE_IN)
             .await?;
 
         Ok(nonce)
     }
 
     pub async fn consume_nonce(&self, nonce: &str) -> Result<Arc<AgentConnection>, RelayError> {
-        let server_id = self.map.remove(&nonce.to_string()).await?;
-        let agent_connection = AgentRegistry::find(&server_id).await?;
+        let device_name = self.map.remove(&nonce.to_string()).await?;
+        let agent_connection = AgentRegistry::find(&device_name).await?;
 
         Ok(agent_connection)
     }

--- a/schema/handshake_v1/f2r.fbs
+++ b/schema/handshake_v1/f2r.fbs
@@ -1,4 +1,4 @@
 table F2rHandshake {
   frontend_version: Version;
-  server_id: string;
+  device_name: string;
 }


### PR DESCRIPTION
I think `--device-name` is more appropriate for non-server machines like personal laptops, IoT devices etc. In addition, I renamed `-id` to `-name` as in near future I plan to implement a feature which would let multiple devices share the same name.