### PR TITLE
build: Skip upload-binaries job if there are no releases.

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -64,6 +64,7 @@ jobs:
   upload-binaries:
     name: Upload Binaries
     needs: release-plz-release
+    if: needs.release-plz-release.outputs.releases != '[]'
 
     strategy:
       matrix:


### PR DESCRIPTION
Fix GitHub Actions from complaining:

```
Error when evaluating 'strategy' for job 'upload-binaries'. .github/workflows/release-plz-release.yml (Line: 70, Col: 18): Matrix vector 'release' does not contain any values
```