### PR TITLE
build: Fix issue with workflow not correctly parsing JSON string.

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -39,7 +39,7 @@ jobs:
         id: parse-releases
         run: |
           echo "Parsing releases from release-plz..."
-          RELEASES="${{ steps.release-plz.outputs.releases }}"
+          RELEASES='${{ steps.release-plz.outputs.releases }}'
           echo "Raw releases data: $RELEASES"
 
           echo "$RELEASES" | jq -c '.[]' | while read release; do


### PR DESCRIPTION
According to job https://github.com/nasa42/webterm/actions/runs/13100985186/job/36549192322, following command is run:

```
  echo "Parsing releases from release-plz..."
  RELEASES="[{"package_name":"webterm-core","prs":[],"tag":"webterm-core-v0.2.1","version":"0.2.1"},{"package_name":"webterm-agent","prs":[],"tag":"webterm-agent-v0.2.1","version":"0.2.1"},{"package_name":"webterm-relay","prs":[],"tag":"webterm-relay-v0.2.1","version":"0.2.1"}]"
  echo "Raw releases data: $RELEASES"

  echo "$RELEASES" | jq -c '.[]' | while read release; do
    package_name=$(echo "$release" | jq -r '.package_name')
    if [[ "$package_name" == "webterm-agent" || "$package_name" == "webterm-relay" ]]; then
      echo "Found relevant release: $package_name"
      echo "$release" >> relevant_releases.jsonl
    else
      echo "Skipping irrelevant release: $package_name"
    fi
  done
  
  if [[ -f relevant_releases.jsonl ]]; then
    FILTERED=$(cat relevant_releases.jsonl | jq -s)
    echo "Filtered releases: $FILTERED"
    echo "releases=$FILTERED" >> $GITHUB_OUTPUT
  else
    echo "No relevant releases found."
    echo "releases=[]" >> $GITHUB_OUTPUT
  fi
```

which results in following

```
Parsing releases from release-plz...
Raw releases data: [{package_name:webterm-core,prs:[],tag:webterm-core-v0.2.1,version:0.2.1},{package_name:webterm-agent,prs:[],tag:webterm-agent-v0.2.1,version:0.2.1},{package_name:webterm-relay,prs:[],tag:webterm-relay-v0.2.1,version:0.2.1}]
jq: parse error: Invalid numeric literal at line 1, column 15
No relevant releases found.
```