### PR TITLE
build: Ask jq to return a single line JSON string.

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -53,7 +53,7 @@ jobs:
           done
 
           if [[ -f relevant_releases.jsonl ]]; then
-            FILTERED=$(cat relevant_releases.jsonl | jq -s)
+            FILTERED=$(cat relevant_releases.jsonl | jq -sc)
             echo "Filtered releases: $FILTERED"
             echo "releases=$FILTERED" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Follow-up to https://github.com/nasa42/webterm/pull/96.

This fixes error in https://github.com/nasa42/webterm/actions/runs/13101293957/job/36549861594

```bash
  if [[ -f relevant_releases.jsonl ]]; then
    FILTERED=$(cat relevant_releases.jsonl | jq -s)
    echo "Filtered releases: $FILTERED"
    echo "releases=$FILTERED" >> $GITHUB_OUTPUT
  else
    echo "No relevant releases found."
    echo "releases=[]" >> $GITHUB_OUTPUT
  fi
```

output

```
Filtered releases: [
  {
    "package_name": "webterm-agent",
    "prs": [],
    "tag": "webterm-agent-v0.2.2",
    "version": "0.2.2"
  },
  {
    "package_name": "webterm-relay",
    "prs": [],
    "tag": "webterm-relay-v0.2.2",
    "version": "0.2.2"
  }
]
Error: Unable to process file command 'output' successfully.
Error: Invalid format '  {'
```