### PR TITLE
build: Set codegen-units to 1 for release profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ license = "MIT"
 repository = "https://github.com/nasa42/webterm"
 
 [profile.release]
+codegen-units = 1
 lto = true


### PR DESCRIPTION
Closes #112.

Set `codegen-units` to `1` for a reduced binary size and potential performance gains.

Before:

![image](https://github.com/user-attachments/assets/8ec4c8f2-6c15-4a60-9fd5-a54841dce860)

After:

![image](https://github.com/user-attachments/assets/1511e0c8-ebf4-4cd2-bfcf-a0f406c1a9c9)
