### PR TITLE
doc: Fix the --relays argument example.

### DIFF
--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -51,7 +51,7 @@ cargo build
 
 ```bash
 # Run the agent and connect to the locally running relay
-cargo run --bin webterm-agent -- --device-name "<device name>" --secret-key "<secret key>" --relays localhost:4200
+cargo run --bin webterm-agent -- --device-name "<device name>" --secret-key "<secret key>" --relays http://localhost:4200
 ```
 
 ## Building the Frontend


### PR DESCRIPTION
Follow-up to #118.

By default `https://` is assumed if protocol is not specified.