### PR TITLE
chore: Update package-lock.json to 0.2.5.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webterm-frontend",
-  "version": "0.0.1",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webterm-frontend",
-      "version": "0.0.1",
+      "version": "0.2.5",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/react": "^4.2.0",


### PR DESCRIPTION
Missed in https://github.com/nasa42/webterm/pull/111.