### PR TITLE
build: Remove grouping from dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,39 +5,15 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 4
-    groups:
-      non-major:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 4
-    groups:
-      non-major:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 4
-    groups:
-      non-major:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
Reverts https://github.com/nasa42/webterm/pull/106.

It seems easier to deal with one package/crate at a time. E.g., https://github.com/nasa42/webterm/pull/129 and https://github.com/nasa42/webterm/pull/130 contain up to 14 packages in a single PR and some of them are causing either dependency mismatch or tests to fail. I think it would be easier to deal with one package update at a time.