### PR TITLE
build: Resolve lifetime elision warning with Rust 1.89.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["agent", "core", "relay"]
 [workspace.package]
 version = "0.2.5"
 edition = "2021"
-rust-version = "1.83.0"
+rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/nasa42/webterm"
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -25,3 +25,16 @@ webterm-core = { path = "../core", version = "0.2.5" }
 
 [lints.clippy]
 new_without_default = "allow"
+# Suppress this fow now:
+#
+# error: the `Err`-variant returned from this function is very large
+#  --> agent/src/models/frontend.rs:76:10
+#   |
+#76 |     ) -> Result<bool, AgentError> {
+#   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+#   |
+#  ::: agent/src/models/agent_error.rs:16:5
+#   |
+#16 |     SocketError(tungstenite::Error),
+#   |     ------------------------------- the largest variant contains at least 136 bytes
+result_large_err = "allow"

--- a/relay/src/handshake/process_a2r_handshake.rs
+++ b/relay/src/handshake/process_a2r_handshake.rs
@@ -10,7 +10,7 @@ use webterm_core::generated::flatbuffers_schema::handshake_v1::{
 use webterm_core::models::device_id::DeviceId;
 use webterm_core::serialisers::handshake_v1::r2a_handshake_builder::R2aHandshakeBuilder;
 
-pub async fn process_a2r_handshake(message: A2rHandshakeRoot<'_>) -> R2aHandshakeBuilder {
+pub async fn process_a2r_handshake(message: A2rHandshakeRoot<'_>) -> R2aHandshakeBuilder<'_> {
     let builder = R2aHandshakeBuilder::new();
 
     match message.root_payload_type() {

--- a/relay/src/handshake/process_f2r_handshake.rs
+++ b/relay/src/handshake/process_f2r_handshake.rs
@@ -7,7 +7,7 @@ use webterm_core::generated::flatbuffers_schema::handshake_v1::{
 };
 use webterm_core::serialisers::handshake_v1::r2f_handshake_builder::R2fHandshakeBuilder;
 
-pub async fn process_f2r_handshake(message: F2rHandshakeRoot<'_>) -> R2fHandshakeBuilder {
+pub async fn process_f2r_handshake(message: F2rHandshakeRoot<'_>) -> R2fHandshakeBuilder<'_> {
     let builder = R2fHandshakeBuilder::new();
 
     match message.root_payload_type() {


### PR DESCRIPTION
Upgrade to Rust 1.89.0 and resolve the new lifetime elision warnings.

```
 error: hiding a lifetime that's elided elsewhere is confusing
  --> relay/src/handshake/process_a2r_handshake.rs:13:62
   |
13 | pub async fn process_a2r_handshake(message: A2rHandshakeRoot<'_>) -> R2aHandshakeBuilder {
   |                                                              ^^      ------------------- the same lifetime is hidden here
   |                                                              |
   |                                                              the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: consistently use `'_`
   |
13 | pub async fn process_a2r_handshake(message: A2rHandshakeRoot<'_>) -> R2aHandshakeBuilder<'_> {
   |                                                                                         ++++

error: hiding a lifetime that's elided elsewhere is confusing
  --> relay/src/handshake/process_f2r_handshake.rs:10:62
   |
10 | pub async fn process_f2r_handshake(message: F2rHandshakeRoot<'_>) -> R2fHandshakeBuilder {
   |                                                              ^^      ------------------- the same lifetime is hidden here
   |                                                              |
   |                                                              the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: consistently use `'_`
   |
10 | pub async fn process_f2r_handshake(message: F2rHandshakeRoot<'_>) -> R2fHandshakeBuilder<'_> {
   |                                                                                         ++++

error: could not compile `webterm-relay` (bin "webterm-relay") due to 2 previous errors
```